### PR TITLE
Change ElasticSearch for Prometheus

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,10 +38,12 @@ tsuru_docker_config: {}
 
 tsuru_nosql: true
 tsuru_inmem: true
+tsuru_metrics: true
 
 tsuruController_device: "/dev/sdb"
 tsuruController_sizeNoSQL: "20%VG"
 tsuruController_sizeInMem: "10%VG"
+tsuruController_sizeMetrics: "35%VG"
 tsuruController_sizePool: "20%VG"
 tsuruController_sizeData: "10%VG"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ tsuru_docker_config: {}
 tsuru_nosql: true
 tsuru_inmem: true
 tsuru_metrics: true
+tsuru_collector: true
 
 tsuruController_device: "/dev/sdb"
 tsuruController_sizeNoSQL: "20%VG"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,12 +38,10 @@ tsuru_docker_config: {}
 
 tsuru_nosql: true
 tsuru_inmem: true
-tsuru_search: true
 
 tsuruController_device: "/dev/sdb"
 tsuruController_sizeNoSQL: "20%VG"
 tsuruController_sizeInMem: "10%VG"
-tsuruController_sizeSearch: "35%VG"
 tsuruController_sizePool: "20%VG"
 tsuruController_sizeData: "10%VG"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Composite role for deploying a Tsuru stack
   company: Stone Payments
   license: MIT license
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
   - name: EL
     versions:

--- a/roles/controller/tasks/container.yml
+++ b/roles/controller/tasks/container.yml
@@ -1,6 +1,8 @@
 ---
-- name: setup docker
-  tags: tsuru_docker
+- name: setup container service
+  tags:
+    - tsuru_container
+    - tsuru_docker
   include_role:
     name: stone-payments.docker
   vars:
@@ -23,3 +25,11 @@
       cert: "{{ tsuru_tlsDockerCert }}"
       key: "{{ tsuru_tlsDockerKey }}"
     docker_config: "{{ tsuru_docker_defaults | combine(tsuru_docker_config, recursive=true) }}"
+
+- name: setup container metric collector
+  tags:
+    - tsuru_collector
+    - tsuru_cadvisor
+  include_role:
+    name: stone-payments.cadvisor
+  when: tsuru_collector

--- a/roles/controller/tasks/container.yml
+++ b/roles/controller/tasks/container.yml
@@ -28,7 +28,7 @@
 
 - name: setup container metric collector
   tags:
-    - tsuru_collector
+    - tsuru_metrics
     - tsuru_cadvisor
   include_role:
     name: stone-payments.cadvisor

--- a/roles/controller/tasks/db.yml
+++ b/roles/controller/tasks/db.yml
@@ -1,6 +1,8 @@
 ---
 - name: setup nosql storage
-  tags: tsuru_nosql
+  tags:
+    - tsuru_nosql
+    - tsuru_mongodb
   include_role:
     name: stone-payments.mongodb
   vars:
@@ -16,7 +18,9 @@
   when: tsuru_nosql
 
 - name: setup inmemory storage
-  tags: tsuru_inmem
+  tags:
+    - tsuru_inmem
+    - tsuru_redis
   include_role:
     name: stone-payments.redis
   vars:
@@ -35,3 +39,11 @@
         auth_pass: "{{ tsuru_passAdmin }}"
         down_after_milliseconds: 10000
   when: tsuru_inmem
+
+- name: setup metrics storage
+  tags:
+    - tsuru_metrics
+    - tsuru_prometheus
+  include_role:
+    name: stone-payments.prometheus
+  when: isMaster and tsuru_metrics

--- a/roles/controller/tasks/db.yml
+++ b/roles/controller/tasks/db.yml
@@ -40,10 +40,12 @@
         down_after_milliseconds: 10000
   when: tsuru_inmem
 
-- name: setup metrics storage
+- name: setup metrics storage and collection
   tags:
     - tsuru_metrics
     - tsuru_prometheus
   include_role:
     name: stone-payments.prometheus
-  when: isMaster and tsuru_metrics
+  vars:
+    prometheus_db: "{{ isMaster }}"
+  when: tsuru_metrics

--- a/roles/controller/tasks/db.yml
+++ b/roles/controller/tasks/db.yml
@@ -35,26 +35,3 @@
         auth_pass: "{{ tsuru_passAdmin }}"
         down_after_milliseconds: 10000
   when: tsuru_inmem
-
-- name: setup search storage
-  tags: tsuru_search
-  include_role:
-    name: stone-payments.elasticsearch
-  vars:
-    es_instance_name: "{{ ansible_hostname }}"
-    es_config:
-        cluster.name: "{{ tsuru_nameRs }}"
-        discovery.zen.ping.unicast.hosts: "{{ tsuru_addrMaster }} {{ tsuru_portSearchTransport }}"
-        network.host: "0.0.0.0"
-        http.port: "{{ tsuru_portSearch }}"
-        transport.tcp.port: "{{ tsuru_portSearchTransport }}"
-        node.data: true
-        node.master: "{{ isMaster }}"
-        bootstrap.memory_lock: false
-    es_heap_size: "1g"
-    es_scripts: false
-    es_templates: false
-    es_version_lock: true
-    es_plugins:
-     - plugin: ingest-geoip
-  when: tsuru_search

--- a/roles/controller/tasks/disk.yml
+++ b/roles/controller/tasks/disk.yml
@@ -5,7 +5,7 @@
     pvs: "{{ tsuruController_device }}"
     state: present
 
-- name: create LVs
+- name: create LVs for all APIs
   lvol:
     vg: "{{ tsuruController_nameVG }}"
     lv: "{{ item.name }}"
@@ -17,7 +17,7 @@
       size: "{{ tsuruController_sizeInMem }}"
   failed_when: false #WORKAROUND FOR BUG https://github.com/ansible/ansible-modules-extras/issues/428
 
-- name: create filesystems
+- name: create filesystems for all APIs
   filesystem:
     fstype: "{{ tsuru_fstype }}"
     dev: "/dev/{{ tsuruController_nameVG }}/{{ item }}"
@@ -26,7 +26,7 @@
     - nosql
     - inmem
 
-- name: mount filesystems
+- name: mount filesystems for all APIs
   mount:
     name: "{{ item.name }}"
     src: "/dev/{{ tsuruController_nameVG }}/{{ item.src }}"
@@ -37,3 +37,24 @@
       src: "nosql"
     - name: "/var/lib/redis"
       src: "inmem"
+
+- block:
+    - name: create prometheus LV for metrics master
+      lvol:
+        vg: "{{ tsuruController_nameVG }}"
+        lv: "metrics"
+        size: "{{ tsuruController_sizeMetrics }}"
+
+    - name: create prometheus filesystem for metrics master
+      filesystem:
+        fstype: "{{ tsuru_fstype }}"
+        dev: "/dev/{{ tsuruController_nameVG }}/metrics"
+        resizefs: false
+
+    - name: mount prometheus filesystem for metrics master
+      mount:
+        name: "/var/lib/prometheus"
+        src: "/dev/{{ tsuruController_nameVG }}/metrics"
+        fstype: "{{ tsuru_fstype }}"
+        state: present
+  when: isMaster

--- a/roles/controller/tasks/disk.yml
+++ b/roles/controller/tasks/disk.yml
@@ -15,8 +15,6 @@
       size: "{{ tsuruController_sizeNoSQL }}"
     - name: inmem
       size: "{{ tsuruController_sizeInMem }}"
-    - name: search
-      size: "{{ tsuruController_sizeSearch }}"
   failed_when: false #WORKAROUND FOR BUG https://github.com/ansible/ansible-modules-extras/issues/428
 
 - name: create filesystems
@@ -27,7 +25,6 @@
   with_items:
     - nosql
     - inmem
-    - search
 
 - name: mount filesystems
   mount:
@@ -40,5 +37,3 @@
       src: "nosql"
     - name: "/var/lib/redis"
       src: "inmem"
-    - name: "/var/lib/elasticsearch"
-      src: "search"

--- a/roles/router/tasks/container.yml
+++ b/roles/router/tasks/container.yml
@@ -1,6 +1,8 @@
 ---
-- name: setup docker
-  tags: tsuru_docker
+- name: setup container service
+  tags:
+    - tsuru_container
+    - tsuru_docker
   include_role:
     name: stone-payments.docker
   vars:
@@ -23,3 +25,11 @@
       cert: "{{ tsuru_tlsDockerCert }}"
       key: "{{ tsuru_tlsDockerKey }}"
     docker_config: "{{ tsuru_docker_defaults | combine(tsuru_docker_config, recursive=true) }}"
+
+- name: setup container metric collector
+  tags:
+    - tsuru_collector
+    - tsuru_cadvisor
+  include_role:
+    name: stone-payments.cadvisor
+  when: tsuru_collector

--- a/roles/router/tasks/container.yml
+++ b/roles/router/tasks/container.yml
@@ -28,7 +28,7 @@
 
 - name: setup container metric collector
   tags:
-    - tsuru_collector
+    - tsuru_metrics
     - tsuru_cadvisor
   include_role:
     name: stone-payments.cadvisor

--- a/roles/router/tasks/main.yml
+++ b/roles/router/tasks/main.yml
@@ -23,6 +23,16 @@
     - tsuru_router
   include: db.yml
 
+- name: setup node metrics collection
+  tags:
+    - tsuru_metrics
+    - tsuru_prometheus
+  include_role:
+    name: stone-payments.prometheus
+  vars:
+    prometheus_db: false
+  when: tsuru_metrics
+
 - name: setup planb router
   tags:
     - tsuru_planb

--- a/roles/worker/tasks/container.yml
+++ b/roles/worker/tasks/container.yml
@@ -1,6 +1,8 @@
 ---
 - name: setup container service
-  tags: tsuru_container
+  tags:
+    - tsuru_container
+    - tsuru_docker
   include_role:
     name: stone-payments.docker
   vars:
@@ -23,3 +25,11 @@
       cert: "{{ tsuru_tlsDockerCert }}"
       key: "{{ tsuru_tlsDockerKey }}"
     docker_config: "{{ tsuru_docker_defaults | combine(tsuru_docker_config, recursive=true) }}"
+
+- name: setup container metric collector
+  tags:
+    - tsuru_collector
+    - tsuru_cadvisor
+  include_role:
+    name: stone-payments.cadvisor
+  when: tsuru_collector

--- a/roles/worker/tasks/container.yml
+++ b/roles/worker/tasks/container.yml
@@ -28,7 +28,7 @@
 
 - name: setup container metric collector
   tags:
-    - tsuru_collector
+    - tsuru_metrics
     - tsuru_cadvisor
   include_role:
     name: stone-payments.cadvisor

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -11,6 +11,16 @@
     - tsuru_worker
   include: disk.yml
 
+- name: setup node metrics collection
+  tags:
+    - tsuru_metrics
+    - tsuru_prometheus
+  include_role:
+    name: stone-payments.prometheus
+  vars:
+    prometheus_db: false
+  when: tsuru_metrics
+
 - name: setup container service
   tags:
     - tsuru_container

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,8 +2,6 @@
 tsuru_portDocker: 2376
 tsuru_portNoSQL: 27017
 tsuru_portInMem: 6379
-tsuru_portSearch: 9200
-tsuru_portSearchTransport: 9300
 tsuru_portSentinel: 26379
 tsuru_portAPI: 28000
 tsuru_portRouter: 25000


### PR DESCRIPTION
This PR changes the ElasticSearch metrics provider for the Tsuru stack to Prometheus, using both cAdvisor and Node Exporter to extract the metrics from all hosts.