### PR TITLE
set a custom parameter and change default timeout value of the tsuru api

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ tsuru_addrMaster: "master.example.com"
 tsuru_nameMaster: "tsuruMaster"
 tsuru_addrAPI: "api.example.com"
 tsuru_quotaUnits: 3
+tsuru_readTimeoutAPI: 5
+tsuru_writeTimeoutAPI: 5
 
 tsuru_URLRegistry: "registry.example.com:5000"
 tsuru_routerImage: "tsuru/planb"

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -43,6 +43,8 @@
     tsuru_api_container_log_driver: "journald"
     tsuru_api_bind_port: "{{ tsuru_portAPI }}"
     tsuru_api_public_address: "{{ tsuru_addrAPI }}"
+    tsuru_api_server_read_timeout: "{{ tsuru_readTimeoutAPI }}"
+    tsuru_api_server_write_timeout: "{{ tsuru_writeAPITimeoutAPI }}"
     tsuru_api_sentinel_master_all: "{{ tsuru_nameMaster }}"
     tsuru_api_sentinel_password_all: "{{ tsuru_passAdmin }}"
     tsuru_api_docker_registry_url: "{{ tsuru_URLRegistry }}"

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -44,7 +44,7 @@
     tsuru_api_bind_port: "{{ tsuru_portAPI }}"
     tsuru_api_public_address: "{{ tsuru_addrAPI }}"
     tsuru_api_server_read_timeout: "{{ tsuru_readTimeoutAPI }}"
-    tsuru_api_server_write_timeout: "{{ tsuru_writeAPITimeoutAPI }}"
+    tsuru_api_server_write_timeout: "{{ tsuru_writeTimeoutAPI }}"
     tsuru_api_sentinel_master_all: "{{ tsuru_nameMaster }}"
     tsuru_api_sentinel_password_all: "{{ tsuru_passAdmin }}"
     tsuru_api_docker_registry_url: "{{ tsuru_URLRegistry }}"


### PR DESCRIPTION
Some times this error (_Error: Failed to connect to tsuru server (https://....), it's probably down._) happens cause network problems. I think this can eventually fix this problem.